### PR TITLE
Update GitHub demos with active projects and latest NuGet packages for Word Library

### DIFF
--- a/WordToPDF/App.config
+++ b/WordToPDF/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/WordToPDF/WordToPDF.csproj
+++ b/WordToPDF/WordToPDF.csproj
@@ -8,8 +8,9 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>WordToPDF</RootNamespace>
     <AssemblyName>WordToPDF</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,23 +32,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=16.3450.0.29, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.16.3.0.29\lib\net45\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.26.1.42\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=16.3450.0.29, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.16.3.0.29\lib\net45\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.26.1.42\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocToPDFConverter.Base, Version=16.3450.0.29, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.16.3.0.29\lib\net45\Syncfusion.DocToPDFConverter.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocToPdfConverter.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocToPDFConverter.WinForms.26.1.42\lib\net462\Syncfusion.DocToPdfConverter.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=16.3450.0.29, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.16.3.0.29\lib\net45\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.26.1.42\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=16.3450.0.29, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.16.3.0.29\lib\net45\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.26.1.42\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=16.3450.0.29, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.16.3.0.29\lib\net45\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.26.1.42\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WordToPDF/packages.config
+++ b/WordToPDF/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="16.3.0.29" targetFramework="net45" />
-  <package id="Syncfusion.DocIO.WinForms" version="16.3.0.29" targetFramework="net45" />
-  <package id="Syncfusion.DocToPDFConverter.WinForms" version="16.3.0.29" targetFramework="net45" />
-  <package id="Syncfusion.Licensing" version="16.3.0.29" targetFramework="net45" />
-  <package id="Syncfusion.OfficeChart.Base" version="16.3.0.29" targetFramework="net45" />
-  <package id="Syncfusion.Pdf.WinForms" version="16.3.0.29" targetFramework="net45" />
+  <package id="Syncfusion.Compression.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocToPDFConverter.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="26.1.42" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
1. Change Syncfusion NuGet versions with * instead of static version in all cross platform samples.
2. Cross platform samples should be .NET 8.0 target. (ASP.NET Core web app, Core console). Change the samples.
3. .NET Framework samples must be .NET 4.6.2 target.
4. Delete projects which reached end of .NET life cycle.